### PR TITLE
Update TypeDoc link to their new domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Please take a quick look at the [contribution guidelines](/contributing.md) firs
 * [Browserify](http://browserify.org/) - CommonJS module bundler. Does not support TypeScript "out of the box", but can be applied with *[Grunt](http://gruntjs.com/) tasks: [grunt-ts](https://www.npmjs.com/package/grunt-ts), [grunt-browserify](https://www.npmjs.com/package/grunt-browserify), [grunt-contrib-uglify](https://www.npmjs.com/package/grunt-contrib-uglify)*
 
 ## Tools
-* [TypeDoc](http://typedoc.io/) - A documentation generator for TypeScript projects
+* [TypeDoc](http://typedoc.org/) - A documentation generator for TypeScript projects
 * [TsLint](https://github.com/palantir/tslint) - TypeScript linter by @palantir
 * [TypeScript Standard](https://github.com/e2tox/typescript-standard) - Zero-configuration TypeScript 2 Standard Validation
 


### PR DESCRIPTION
Relevant: TypeStrong/typedoc#285