### PR TITLE
Add Atlas of Economic Complexity

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,9 @@ Please take a quick look at the [contribution guidelines](/contributing.md) firs
 * :octocat: [wretch](https://github.com/elbywan/wretch) - A tiny (< 2.2Kb g-zipped) wrapper built around fetch with an intuitive syntax.
 * :octocat: [Cycle.js](https://github.com/cyclejs/cyclejs) - A functional and reactive JavaScript framework for predictable code.
 
+### Web Apps
+* [Atlas of Economic Complexity](http://atlas.cid.harvard.edu/) - Research and data visualization tool to explore global trade flows across markets, track these dynamics over time and discover new growth opportunities for every country.
+
 ### Standalone apps
 * :octocat: [Visual Studio Code](https://github.com/Microsoft/vscode) - Multiplatform IDE.
 * :octocat: [alm - A next generation IDE just for TypeScript written in TypeScript + React](https://github.com/alm-tools/alm)


### PR DESCRIPTION
I think this is a useful addition to the list because the Atlas is a fairly large (50k TypeScript LOC) and popular (about 30,000 visitors/month) application that shows how `typescript` can be used at scale. I created a new section because it doesn't fit the existing ones but this can change.