### PR TITLE
Add https://agentcooper.github.io/typescript-play/

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Please take a quick look at the [contribution guidelines](/contributing.md) firs
 #### Online
 
 ##### Playground
+* [TypeScript playground](https://agentcooper.github.io/typescript-play/) by @agentcooper, supports multiple TS versions and compiler targets
 * [TypeScript playground-on-ace](https://github.com/hi104/typescript-playground-on-ace) by @hi104 [updated to TypeScript 1.5](https://github.com/basarat/TypeScriptEditor)
 * [TypeScript official Playground](http://www.typescriptlang.org/Playground/)
 * [JS Bin](http://jsbin.com/?js) (Select TypeScript)


### PR DESCRIPTION
I took the liberty of adding this playground as the first entry on the list, since it supports latest TS (2.8) and provides more compiler options than the original one.