### PR TITLE
Replace create-react-app-typescript (deprecated) with create-react-app

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Please take a quick look at the [contribution guidelines](/contributing.md) firs
 
 ### TypeScript for...
 #### React
-* :octocat: [wmonk/create-react-app-typescript](https://github.com/wmonk/create-react-app-typescript) Create React apps using typescript with no build configuration; based on `create-react-app`
+* :octocat: [facebook/create-react-app](https://facebook.github.io/create-react-app/docs/adding-typescript) Create React apps using typescript with no build configuration
 * :octocat: [Microsoft/TypeScript-React-Starter](https://github.com/Microsoft/TypeScript-React-Starter) A starter template for TypeScript and React with a detailed README describing how to use the two together; based on `create-react-app`
 * :scroll: [typescript-cheatsheets/react-typescript-cheatsheet](https://github.com/typescript-cheatsheets/react-typescript-cheatsheet) Cheatsheets for experienced React developers getting started with TypeScript 
 * :octocat: [jsxtyper](https://github.com/fuselabs/jsxtyper) Generates TypeScript interfaces from .jsx files


### PR DESCRIPTION
Now that CRA supports TypeScript out of the box, and create-react-app-typescipt has been officially deprecated it shouldn't be on the list anymore.