### PR TITLE
Add FoalTS to "Backend API" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Please take a quick look at the [contribution guidelines](/contributing.md) firs
 ### Back-end API
 * :octocat: [design-first](https://adam-hanna.github.io/design-first-docs/) - A REST api templating engine for Typescript
 * :octocat: [Nest](https://github.com/nestjs/nest) - A progressive Node.js framework for building efficient, scalable, and enterprise-grade server-side applications on top of TypeScript 🚀 (see also: https://nestjs.com/)
+* :octocat: [FoalTS](https://github.com/FoalTS/foal) - A simple, intuitive and complete framework for building enterprise-grade Node.JS applications :boom: :rocket: (see also: https://foalts.org)
 
 ### Standalone apps
 * :octocat: [Visual Studio Code](https://github.com/Microsoft/vscode) - Multiplatform IDE.


### PR DESCRIPTION
Add [FoalTS](https://github.com/FoalTS/foal) framework to "Backend API" section.