### PR TITLE
Adding subsection for type validation/inference libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Please take a quick look at the [contribution guidelines](/contributing.md) firs
 ## Validation
 * [io-ts](https://github.com/gcanti/io-ts) - Runtime type system for IO decoding/encoding
 * [zod](https://github.com/vriad/zod) - TypeScript-first schema validation with static type inference
-* [runtypes](https://github.com/vriad/zod) - Runtime validation for static types
+* [runtypes](https://github.com/pelotom/runtypes) - Runtime validation for static types
 * [ow](https://github.com/sindresorhus/ow) - Function argument validation for humans
 * [superstruct](https://github.com/ianstormtaylor/superstruct) - A simple and composable way to validate data
 * [computed-types](https://github.com/neuledge/computed-types) - 🦩 Joi like validations for TypeScript

--- a/README.md
+++ b/README.md
@@ -149,11 +149,18 @@ Please take a quick look at the [contribution guidelines](/contributing.md) firs
 * [typesync](https://github.com/jeffijoe/typesync) - Install missing TypeScript typings for dependencies in your package.json.
 * [type-fest](https://github.com/sindresorhus/type-fest) - A collection of essential TypeScript types
 ### Runtime
-* [io-ts](https://github.com/gcanti/io-ts) - Runtime type system for IO decoding/encoding
 * [json-decoder](https://github.com/venil7/json-decoder) - Typesafe JSON decoder and runtime checker
 * [typescript-is](https://github.com/woutervh-/typescript-is) - TypeScript transformer that generates run-time type-checks.
 * [type-plus](https://github.com/unional/type-plus) - Additional types and type adjusted utilities
+
+## Validation
+* [io-ts](https://github.com/gcanti/io-ts) - Runtime type system for IO decoding/encoding
+* [zod](https://github.com/vriad/zod) - TypeScript-first schema validation with static type inference
+* [runtypes](https://github.com/vriad/zod) - Runtime validation for static types
+* [ow](https://github.com/sindresorhus/ow) - Function argument validation for humans
+* [superstruct](https://github.com/ianstormtaylor/superstruct) - A simple and composable way to validate data
 * [computed-types](https://github.com/neuledge/computed-types) - 🦩 Joi like validations for TypeScript
+
 
 ## Built with TypeScript
 ### Mobile


### PR DESCRIPTION
This is a very clearly-defined category that deserves it's own section. There are many TypeScript-specific tools for defining Yup-style validators while simultaneously inferred a static typescript type, thus avoiding duplicative static and runtime definitions.

I'm very familiar with this category since I maintain one of these libraries (https://github.com/vriad/zod). I also added in all major alternatives to my library, as well as re-categorizing `io-ts` (the most popular TS validation library currently).