### PR TITLE
Add tinyhttp to a list of Back-End APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ Please take a quick look at the [contribution guidelines](/contributing.md) firs
 * :octocat: [FoalTS](https://github.com/FoalTS/foal) - A simple, intuitive and complete framework for building enterprise-grade Node.JS applications :boom: :rocket: (see also: https://foalts.org)
 * :octocat: [Enso](http://ensojs.netlify.com) - Typescript first Node.JS framework inspired by Domain Driven Design principles with a focus on composition and Developer Experience
 * :octocat: [Libstack](https://libstack.io) - A collection of various modules to create Typescript server easily and ready to be deployed on Docker.
+* :octocat: [tinyhttp](https://github.com/talentlessguy/tinyhttp) - A modern Express-like web framework for Node.js, written in TypeScript and compiled to Native ESM.
 
 ### Standalone apps
 * :octocat: [Visual Studio Code](https://github.com/Microsoft/vscode) - Multiplatform IDE.


### PR DESCRIPTION
tinyhttp is a modern Express-like web framework for Node.js, written in TypeScript and compiled to native ESM. It uses a bare minimum amount of dependencies trying to avoid legacy hell.

Site: https://tinyhttp.v1rtl.site
Repo: https://github.com/talentlessguy/tinyhttp

the project itself, at the moment of adding this PR has 116 stars and 6 (including myself) contributors. Was created on June 13, so more than 30 days passed. Test coverage is 32%.

I think I followed all the requirements, let me know if I missed anything!