### PR TITLE
Removed TSLint - deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,6 @@ Please take a quick look at the [contribution guidelines](/contributing.md) firs
 * [deno](https://deno.land/) - A secure runtime for JavaScript and TypeScript
 * [SweetIQ/schemats](https://github.com/SweetIQ/schemats) Generate typescript interface definitions from SQL database schema
 * [TypeDoc](http://typedoc.org/) - A documentation generator for TypeScript projects
-* [TsLint](https://github.com/palantir/tslint) - TypeScript linter by @palantir
 * [TypeScript Standard](https://github.com/e2tox/typescript-standard) - Zero-configuration TypeScript 2 Standard Validation
 * [typed-install](https://github.com/xavdid/typed-install) - Easily install new dependencies and their typings, no matter where they may be
 * [Interactive TypeScript AST Viewer](https://ast.carlosroso.com/) - Write TypeScript snippets and explore its AST.


### PR DESCRIPTION
The TSLint library is deprecated, according to the official [github page](https://github.com/palantir/tslint).