### PR TITLE
Add tutorials section with a first tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Please take a quick look at the [contribution guidelines](/contributing.md) firs
 - [Runtime](#runtime)
 - [Built with TypeScript: Mobile, Web, Back-end API, Standalone apps, Libraries](#built-with-typescript)
 - [Video Courses](#video-courses)
+- [Tutorials](#tutorials)
 
 ## Getting Started with (Awesome) TypeScript
 

--- a/README.md
+++ b/README.md
@@ -285,6 +285,10 @@ Please take a quick look at the [contribution guidelines](/contributing.md) firs
 * [TypeScript: The Complete Developer's Guide](https://www.udemy.com/typescript-the-complete-developers-guide/) (Udemy)
 * [Angular with TypeScript](https://www.manning.com/livevideo/angular-for-java-developers-typescript/) (Manning)
 
+# Tutorials
+
+* [Converting your vanilla JavaScript app to TypeScript](https://www.useanvil.com/blog/engineering/converting-vanilla-javascript-to-typescript)
+
 ### Badges
 * [TypeScript Badges](https://github.com/ellerbrock/typescript-badges/)
 [![TypeScript](https://raw.githubusercontent.com/ellerbrock/typescript-badges/master/badges/awesome/typescript125x28.png)](https://github.com/ellerbrock/typescript-badges/) [![TypeScript](https://raw.githubusercontent.com/ellerbrock/typescript-badges/master/badges/code/typescript-125x28.png)](https://github.com/ellerbrock/typescript-badges/) [![TypeScript](https://raw.githubusercontent.com/ellerbrock/typescript-badges/master/badges/love/typescript-125x28.png)](https://github.com/ellerbrock/typescript-badges/)


### PR DESCRIPTION
This adds a new tutorials section with a first tutorial

<img width="770" alt="Screen Shot 2022-05-23 at 5 31 37 PM" src="https://user-images.githubusercontent.com/69169/169925247-3313a928-d47e-4428-bc04-d9853d6323ae.png">

