### PR TITLE
Add sqlx-ts under tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Please take a quick look at the [contribution guidelines](/contributing.md) firs
 * [Factor](https://factor.dev) - The Javascript CMS (TypeScript supported natively)
 
 ## Tools
+* [sqlx-ts](https://github.com/JasonShin/sqlx-ts) - SQLx-ts is a CLI application featuring compile-time checked queries without a DSL and generates types against SQLs to keep your code type-safe
 * [deno](https://deno.land/) - A secure runtime for JavaScript and TypeScript
 * [SweetIQ/schemats](https://github.com/SweetIQ/schemats) Generate typescript interface definitions from SQL database schema
 * [TypeDoc](http://typedoc.org/) - A documentation generator for TypeScript projects


### PR DESCRIPTION
Hi, I've recently worked on a project `sqlx-ts`

https://github.com/JasonShin/sqlx-ts

blog articles: https://functional.works-hub.com/learn/sqlx-ts-compile-time-checked-queries-with-dsl-in-typescript-9c47b

It is a tool that is featuring compile-time checked queries without a DSL and generates types against SQLs to keep your code type-safe. Also I firmly believe that it is a replacement of `schemats` listed under https://github.com/dzharii/awesome-typescript/blob/master/README.md#tools
-> This is because the project is unmaintained and sqlx-ts is written in Rust with all the modern capabilities