### PR TITLE
added `valibot` library

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Please take a quick look at the [contribution guidelines](/contributing.md) firs
 ## Validation
 * [io-ts](https://github.com/gcanti/io-ts) - Runtime type system for IO decoding/encoding
 * [zod](https://github.com/vriad/zod) - TypeScript-first schema validation with static type inference
+* [valibot](https://github.com/fabian-hiller/valibot) - Valibot is a Typescript schema library with static type inference, and it's exceptionally lightweight compared to Zod, with no dependencies.
 * [runtypes](https://github.com/pelotom/runtypes) - Runtime validation for static types
 * [ts-codec](https://github.com/julienvincent/ts-codec) - TypeScript Codecs for encoding, decoding and validating data
 * [ow](https://github.com/sindresorhus/ow) - Function argument validation for humans


### PR DESCRIPTION
Valibot is a relatively new schema library, released in July of 2023: [Tweet](https://x.com/FabianHiller/status/1683841850401251333?s=20). It has quickly gained popularity due to its lightweight nature, which is a result of its modular API design. This design allows bundlers to remove unneeded code using import statements, meaning only the necessary code makes it into the production build

Example code from [Valibot Repo](https://github.com/fabian-hiller/valibot#example):

```ts
import { email, minLength, object, type Output, parse, string } from 'valibot'; // 0.76 kB

// Create login schema with email and password
const LoginSchema = object({
  email: string([email()]),
  password: string([minLength(8)]),
});

// Infer output TypeScript type of login schema
type LoginData = Output<typeof LoginSchema>; // { email: string; password: string }

// Throws error for `email` and `password`
parse(LoginSchema, { email: '', password: '' });

// Returns data as { email: string; password: string }
parse(LoginSchema, { email: 'jane@example.com', password: '12345678' });
```

---

Zod bundle size according to [Bundlephobia](https://bundlephobia.com/package/zod@3.22.4):

![zod](https://github.com/dzharii/awesome-typescript/assets/72913359/1a853cbc-bb1c-496a-b0da-b05a198b9479)

ValiBot bundle size according to [Bundlephobia](https://bundlephobia.com/package/valibot@0.19.0):

![valibot](https://github.com/dzharii/awesome-typescript/assets/72913359/c64f724c-79b8-4bc7-a705-26564e7236ce)
 
