### PR TITLE
added `vite` bundler

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Please take a quick look at the [contribution guidelines](/contributing.md) firs
 * [DDB-Table](https://github.com/neuledge/ddb-table) Strongly typed querys and tables for AWS DynamoDB
 
 ## Module Bundlers
+* [Vite](https://vitejs.dev/) - Next Generation Frontend Tooling
 * [Webpack](http://webpack.github.io/) - supports CommonJS and AMD module bundling
   - :scroll: [TypeScript and webpack](http://www.jbrantly.com/typescript-and-webpack/) - How to configure Webpack for TypeScript with source map support
 * [Browserify](http://browserify.org/) - CommonJS module bundler. Does not support TypeScript "out of the box", but can be applied with * [Grunt](http://gruntjs.com/) tasks: [grunt-ts](https://www.npmjs.com/package/grunt-ts), [grunt-browserify](https://www.npmjs.com/package/grunt-browserify), [grunt-contrib-uglify](https://www.npmjs.com/package/grunt-contrib-uglify)


### PR DESCRIPTION
[Vite](https://vitejs.dev/) is a bundler that is way faster than Webpack

**Features**:
- **Instant Server Start**:
  * On-demand file serving over native ESM, no bundling required
- **Lightning Fast HMR**:
  * Hot Module Replacement (HMR) that stays fast regardless of app size
- **Fully Typed APIs**:
  * Flexible programmatic APIs with full TypeScript typing
- **Optimized Build**:
  * Pre-configured Rollup build with multi-page and library mode support