### PR TITLE
added `bun`

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Please take a quick look at the [contribution guidelines](/contributing.md) firs
 
 ## Tools
 * [sqlx-ts](https://github.com/JasonShin/sqlx-ts) - SQLx-ts is a CLI application featuring compile-time checked queries without a DSL and generates types against SQLs to keep your code type-safe
+* [bun](https://bun.sh/) - Bun is a fast JavaScript runtime, package manager, bundler, test runner
 * [deno](https://deno.land/) - A secure runtime for JavaScript and TypeScript
 * [SweetIQ/schemats](https://github.com/SweetIQ/schemats) Generate typescript interface definitions from SQL database schema
 * [TypeDoc](http://typedoc.org/) - A documentation generator for TypeScript projects


### PR DESCRIPTION
[Bun](https://bun.sh/) is an all-in-one JavaScript runtime & toolkit designed for speed, complete with a bundler, [test runner](https://bun.sh/docs/cli/test), and Node.js-compatible [package manager](https://bun.sh/package-manager). It ships as a single executable called `bun`.

At its core is the Bun runtime, a fast JavaScript runtime designed as a drop-in replacement for Node.js. It's written in Zig and powered by **JavaScriptCore** under the hood, dramatically reducing startup times and memory usage.