### PR TITLE
chore: add ts-vite-npm-template

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Please take a quick look at the [contribution guidelines](/contributing.md) firs
 * :octocat: [samchon/backend](https://github.com/samchon/backend) - TypeScript backend template project using the [NestJS](https://nestjs.com) ([nestia](https://github.com/samchon/nestia)) and [TypeORM](https://typeorm.io) ([safe-typeorm](https://github.com/samchon/safe-typeorm)). It helps newbie backend developers through the derived example projects. Also, it even supports the non-distruptive update system in the process level through the [pm2](https://pm2.keymetrics.io/).
 * :ok_man: [ts-express-boilerplate](https://github.com/d4rkstar/ts-express-boilerplate) - ExpressJS / Typescript template good to start backend projects, with a focus on simplicity and minimal features :P It has logging and testing configured out of the box. Typeorm is used for data access.
 * [create-typescript-app](https://github.com/hein-htut-aung/create-typescript-app) - provides a starting point for TypeScript web applications. pnpm, Rollup, Jest, and CSS Modules with SCSS.
+* [ts-vite-npm-template](https://github.com/kaandesu/ts-vite-npm-template) - An all-in-one solution for crafting TypeScript-based NPM packages with Vite, complete with built-in GitHub Pages live-demo deployment, automated test-and-build workflows, and Vite-powered unit test configuration, including coverage analysis and a README.md template for your package.
 
 ### Books
 * :books: [TypeScript in 50 Lessons](https://typescript-book.com/) by Stefan Baumgartner


### PR DESCRIPTION
Description: A template for creating TypeScript-based NPM packages with Vite, with built-in GitHub Pages live-demo deployment workflow, test-and-build workflow, and Vite-powered unit test configuration, including coverage analysis and a README.md template.

Note: I made this template locally for my personal npm projects, but after seeing this repo decided to turn it into a public template to share... This template saves a lot of time that would go to just configuring stuff.