### PR TITLE
changed next-color to color-core

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ Please take a quick look at the [contribution guidelines](/contributing.md) firs
 * :octocat: [castore](https://github.com/castore-dev/castore) - Typescript library to easily implement Event Sourcing in your application
 * :octocat: [sweet-monads](https://github.com/JSMonk/sweet-monads) - Typescript library for popular monads (such as `Maybe` or `Either`) and performant iterators.
 * :octocat: [simple-mask-money](https://github.com/codermarcos/simple-mask-money) - 💰 Simple mask money is a light, safe and typed package to format money!
-* :octocat: [Next Colors](https://github.com/iamlite/next-colors) - Next-Colors is a comprehensive color manipulation library for Next.js and React applications.
+* :octocat: [Color-Core](https://github.com/iamlite/color-core) - `color-core` is a powerful, type-safe color manipulation library for TypeScript and JavaScript applications. It provides a comprehensive toolkit for working with colors across multiple color spaces, making it an indispensable tool for developers working on projects that require advanced color handling.
 
 # Video Courses
 ## :free: Free Courses


### PR DESCRIPTION
changed name and link to next-color repo. New name is color-core. Same functionality.