### PR TITLE
Add React Starter Kit

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Please take a quick look at the [contribution guidelines](/contributing.md) firs
 - :books: [TypeScript Style Guide](https://mkosir.github.io/typescript-style-guide) A concise set of conventions and best practices for creating consistent, maintainable code.
 
 ### Typescript Project Starters
+* [React Starter Kit](https://github.com/kriasoft/react-starter-kit) – A full-stack boilerplate for building modern web applications with Bun, TypeScript, React, tRPC, Drizzle ORM, and Cloudflare Workers.
 * [typescript-starter](https://github.com/bitjson/typescript-starter) – A CLI to quickly generate and configure new libraries and Node.js projects
 * [next-smrt](https://github.com/csprance/next-smrt) – A Typescript/NextJs boilerplate with Redux/Styled Components/Material UI and TypeSafe Actions.
 * :octocat: [Next-Postgres-With-Typescript](https://github.com/brandontle/next-postgres-with-typescript) - Forum-like fullstack web app boilerplate with Next.js 7.0.2 + Sequelize 4/Postgres + Typescript + Redux + Passport Local Auth + Emotion


### PR DESCRIPTION
React Starter Kit is a boilerplate for building modern full-stack web applications with Bun, TypeScript, React, tRPC, and Drizzle ORM. It is designed to be a starting point for developers who want to create modern web applications with a focus on performance, simplicity, and best practices, with out-of-the-box support for edge-native deployment on Cloudflare Workers.

Repository: https://github.com/kriasoft/react-starter-kit
License: MIT