### PR TITLE
Add Veritas Kanban to Built with TypeScript (Web/ReactJS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ Please take a quick look at the [contribution guidelines](/contributing.md) firs
 * :scroll: [typescript-cheatsheets/react-typescript-cheatsheet](https://github.com/typescript-cheatsheets/react-typescript-cheatsheet) Cheatsheets for experienced React developers getting started with TypeScript
 * :octocat: [jsxtyper](https://github.com/fuselabs/jsxtyper) Generates TypeScript interfaces from .jsx files
 * :octocat: [TodoMVC • TypeScript + React Example](https://github.com/tastejs/todomvc/tree/gh-pages/examples/typescript-react)
+* :octocat: [Veritas Kanban](https://github.com/BradGroux/veritas-kanban) - Self-hosted Kanban board with AI agent integration, built with React 19, TypeScript strict mode, Vite 6, and 1,255 tests.
 * :scroll: [Working with React and TypeScript](http://blog.wolksoftware.com/working-with-react-and-typescript)
 * :guardsman: [**vortigern** - A universal boilerplate for building web applications w/ TypeScript, React, Redux and more.](https://github.com/barbar/vortigern)
 * :robot: [Convert React code to TypeScript automatically](https://github.com/lyft/react-javascript-to-typescript-transform)


### PR DESCRIPTION
Adds [Veritas Kanban](https://github.com/BradGroux/veritas-kanban) to the Web/ReactJS section under Built with TypeScript.

Self-hosted Kanban board with AI agent integration, built with:
- TypeScript strict mode throughout (frontend + backend + shared types)
- React 19, Vite 6, Express
- 1,255 tests (Vitest + Playwright E2E)
- 55K lines of TypeScript across 347 files

67+ GitHub stars, trending on r/reactjs.