### PR TITLE
Add Opik to project list

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ Please take a quick look at the [contribution guidelines](/contributing.md) firs
 * :octocat: [Bobril](https://github.com/Bobris/Bobril) - Component oriented framework inspired by Mithril and ReactJs. (see also: http://bobril.com/)
 * :octocat: [Stencil](https://github.com/ionic-team/stencil) - a tool for building modern Web Components
 * :octocat: [Langfuse](https://github.com/langfuse/langfuse) - Open source LLM engineering platform 🪢 - Tracing, Prompt Mgmt, Evaluations, Analytics
+* :octocat: [Opik](https://github.com/comet-ml/opik) - Open-source platform for LLM observability, evaluations, and prompt optimization
 * :octocat: [redux-zero](https://github.com/concretesolutions/redux-zero) - A lightweight state container based on Redux
 * :octocat: [wretch](https://github.com/elbywan/wretch) - A tiny (< 2.2Kb g-zipped) wrapper built around fetch with an intuitive syntax.
 * :octocat: [Cycle.js](https://github.com/cyclejs/cyclejs) - A functional and reactive JavaScript framework for predictable code.


### PR DESCRIPTION
## Summary
- add Opik to the relevant observability/evaluation section
- keep formatting consistent with the existing list structure

Opik: open-source platform for LLM observability, evaluations, and prompt optimization.